### PR TITLE
Make --debug/--no-debug a bit more useful.

### DIFF
--- a/check_haproxy.rb
+++ b/check_haproxy.rb
@@ -81,9 +81,11 @@ else
   if down_proxies.length > 0
     puts down_proxies.join(" ")
   else
-    puts "All proxies UP"
+    puts "All " + @messages.length.to_s + " proxies UP"
   end
-  puts @messages.reject { |m| m.match(/DOWN/) }
+  if options.debug
+    puts @messages.reject { |m| m.match(/DOWN/) }
+  end
 end
 
 exit exit_code


### PR DESCRIPTION
Also adds the number of detected proxies to the default "all up" output, to simplify debugging.
